### PR TITLE
[agent] add project documentation placeholders

### DIFF
--- a/.rooignore
+++ b/.rooignore
@@ -1,0 +1,1 @@
+# Access control and security rules placeholder

--- a/.roomodes
+++ b/.roomodes
@@ -1,0 +1,2 @@
+# Custom Modes Configuration
+Placeholder for custom modes.

--- a/acceptance-criteria.md
+++ b/acceptance-criteria.md
@@ -1,0 +1,3 @@
+# Acceptance Criteria
+
+Placeholder for Testable requirements.

--- a/api-docs.md
+++ b/api-docs.md
@@ -1,0 +1,3 @@
+# Api Docs
+
+Placeholder for API documentation.

--- a/architecture.md
+++ b/architecture.md
@@ -1,0 +1,3 @@
+# Architecture
+
+Placeholder for System architecture document.

--- a/debug-report.md
+++ b/debug-report.md
@@ -1,0 +1,3 @@
+# Debug Report
+
+Placeholder for Debugging analysis.

--- a/decision-trees.md
+++ b/decision-trees.md
@@ -1,0 +1,3 @@
+# Decision Trees
+
+Placeholder for Decision frameworks.

--- a/delivery-report.md
+++ b/delivery-report.md
@@ -1,0 +1,3 @@
+# Delivery Report
+
+Placeholder for Final delivery documentation.

--- a/documentation-plan.md
+++ b/documentation-plan.md
@@ -1,0 +1,3 @@
+# Documentation Plan
+
+Placeholder for Documentation strategy.

--- a/faq.md
+++ b/faq.md
@@ -1,0 +1,3 @@
+# Faq
+
+Placeholder for Frequently asked questions.

--- a/function-specs.md
+++ b/function-specs.md
@@ -1,0 +1,3 @@
+# Function Specs
+
+Placeholder for Function specifications.

--- a/incident-response.md
+++ b/incident-response.md
@@ -1,0 +1,3 @@
+# Incident Response
+
+Placeholder for Incident procedures.

--- a/integration-report.md
+++ b/integration-report.md
@@ -1,0 +1,3 @@
+# Integration Report
+
+Placeholder for System integration results.

--- a/monitoring-dashboard.md
+++ b/monitoring-dashboard.md
@@ -1,0 +1,3 @@
+# Monitoring Dashboard
+
+Placeholder for Operations monitoring.

--- a/operations-guide.md
+++ b/operations-guide.md
@@ -1,0 +1,3 @@
+# Operations Guide
+
+Placeholder for Operational procedures.

--- a/optimization-report.md
+++ b/optimization-report.md
@@ -1,0 +1,3 @@
+# Optimization Report
+
+Placeholder for Performance optimization.

--- a/personas.md
+++ b/personas.md
@@ -1,0 +1,3 @@
+# Personas
+
+Placeholder for User personas.

--- a/project-plan.md
+++ b/project-plan.md
@@ -1,0 +1,3 @@
+# Project Plan
+
+Placeholder for Project management plan.

--- a/pseudocode.md
+++ b/pseudocode.md
@@ -1,0 +1,3 @@
+# Pseudocode
+
+Placeholder for Implementation algorithms.

--- a/qa-plan.md
+++ b/qa-plan.md
@@ -1,0 +1,3 @@
+# Qa Plan
+
+Placeholder for Quality assurance strategy.

--- a/security-architecture.md
+++ b/security-architecture.md
@@ -1,0 +1,3 @@
+# Security Architecture
+
+Placeholder for Security design.

--- a/specification.md
+++ b/specification.md
@@ -1,0 +1,3 @@
+# Specification
+
+Placeholder for Core project specification.

--- a/stakeholder-reports.md
+++ b/stakeholder-reports.md
@@ -1,0 +1,3 @@
+# Stakeholder Reports
+
+Placeholder for Stakeholder communications.

--- a/tech-stack-evaluation.md
+++ b/tech-stack-evaluation.md
@@ -1,0 +1,3 @@
+# Tech Stack Evaluation
+
+Placeholder for Technology selection rationale.

--- a/technology-architecture.md
+++ b/technology-architecture.md
@@ -1,0 +1,3 @@
+# Technology Architecture
+
+Placeholder for Technology stack design.

--- a/test-strategy.md
+++ b/test-strategy.md
@@ -1,0 +1,3 @@
+# Test Strategy
+
+Placeholder for Testing approach.

--- a/threat-model.md
+++ b/threat-model.md
@@ -1,0 +1,3 @@
+# Threat Model
+
+Placeholder for Security threat analysis.

--- a/traceability-matrix.md
+++ b/traceability-matrix.md
@@ -1,0 +1,3 @@
+# Traceability Matrix
+
+Placeholder for Requirements traceability.

--- a/troubleshooting.md
+++ b/troubleshooting.md
@@ -1,0 +1,3 @@
+# Troubleshooting
+
+Placeholder for Troubleshooting guide.

--- a/user-guide.md
+++ b/user-guide.md
@@ -1,0 +1,3 @@
+# User Guide
+
+Placeholder for End user documentation.

--- a/user-scenarios.md
+++ b/user-scenarios.md
@@ -1,0 +1,3 @@
+# User Scenarios
+
+Placeholder for User journey definitions.


### PR DESCRIPTION
## Summary
- add custom mode and ignore configuration stubs
- scaffold 29 root-level documentation placeholders for specs, architecture, security, testing, and operations

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68981aaae824832295973004f7c2e195