### PR TITLE
[agent] add memory bank placeholders

### DIFF
--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -1,0 +1,3 @@
+# Active Context
+
+Tracks current assumptions, objectives, and operational context for the AI video pipeline. Sensitive details should reference environment variables (e.g., `$API_KEY`) rather than embedding secrets directly.

--- a/memory-bank/dataPatterns.md
+++ b/memory-bank/dataPatterns.md
@@ -1,0 +1,3 @@
+# Data Patterns
+
+Documents recurring data structures and flows, highlighting validation rules and storage considerations. Sensitive dataset paths or keys should be represented using environment variables like `$DATASET_PATH`.

--- a/memory-bank/decisionLog.md
+++ b/memory-bank/decisionLog.md
@@ -1,0 +1,3 @@
+# Decision Log
+
+Records major architectural or process decisions and their rationale. Any references to confidential tokens or credentials must point to environment variables such as `$SERVICE_TOKEN`.

--- a/memory-bank/productContext.md
+++ b/memory-bank/productContext.md
@@ -1,0 +1,3 @@
+# Product Context
+
+Outlines the product goals, target users, and constraints influencing development. Sensitive configuration, like database URLs, should use environment variables (e.g., `$DATABASE_URL`).

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -1,0 +1,3 @@
+# Progress
+
+Summarizes milestones and ongoing tasks for the AI video pipeline. When referencing protected resources, use environment variables like `$S3_BUCKET`.

--- a/memory-bank/systemPatterns.md
+++ b/memory-bank/systemPatterns.md
@@ -1,0 +1,3 @@
+# System Patterns
+
+Captures common architectural and operational patterns observed in the system. Any example secrets must be expressed via environment variables, such as `$JWT_SECRET`.


### PR DESCRIPTION
## Summary
- scaffold `memory-bank/` with markdown placeholders for active context, decision log, product context, progress, system patterns, and data patterns
- document use of environment variables for all sensitive data references

## Testing
- `ruff check .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68981e4fd3e88322a519495b720c8d34