### PR TITLE
[agent] docs: add initial documentation skeleton

### DIFF
--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -1,0 +1,3 @@
+# Architecture Documentation
+
+This folder contains technical architecture resources for the AI video pipeline. All designs must respect the security requirements: never hardcode API keys, always validate user inputs, include timeout and retry logic for API calls, and use try-catch with custom exceptions.

--- a/docs/architecture/technicalArchitecture.md
+++ b/docs/architecture/technicalArchitecture.md
@@ -1,0 +1,3 @@
+# Technical Architecture
+
+Placeholder for detailed technical diagrams and component interactions. Content here must follow the security requirements: avoid hardcoded API keys, validate user input, add timeout and retry logic for API calls, and handle errors with custom exceptions.

--- a/docs/personas/README.md
+++ b/docs/personas/README.md
@@ -1,0 +1,3 @@
+# Personas Documentation
+
+This folder captures user personas that interact with the AI video pipeline. Each persona assumes adherence to security requirements: avoid hardcoded API keys, validate user inputs, include timeout and retry logic for API calls, and handle errors with custom exceptions.

--- a/docs/requirements/README.md
+++ b/docs/requirements/README.md
@@ -1,0 +1,3 @@
+# Requirements Documentation
+
+This folder gathers business, operational, and quality requirements. All requirements must honor the security principles: do not hardcode API keys, validate all user inputs, incorporate timeout and retry logic for API calls, and wrap operations in custom exception handling.

--- a/docs/requirements/businessIntelligence.md
+++ b/docs/requirements/businessIntelligence.md
@@ -1,0 +1,3 @@
+# Business Intelligence
+
+Placeholder for business intelligence requirements. Ensure that any analytics workflows avoid hardcoded API keys, validate incoming data, use timeout and retry logic for API calls, and implement custom exception handling.

--- a/docs/requirements/operationalProcedures.md
+++ b/docs/requirements/operationalProcedures.md
@@ -1,0 +1,3 @@
+# Operational Procedures
+
+Placeholder for operational procedures. All procedures must enforce security requirements: avoid hardcoded API keys, validate user inputs, include timeout and retry logic for API calls, and use custom exceptions to handle errors.

--- a/docs/requirements/qualityAssurance.md
+++ b/docs/requirements/qualityAssurance.md
@@ -1,0 +1,3 @@
+# Quality Assurance
+
+Placeholder for quality assurance guidelines. Testing strategies must avoid hardcoded API keys, validate all inputs, apply timeout and retry logic for API calls, and capture failures with custom exceptions.

--- a/docs/security/README.md
+++ b/docs/security/README.md
@@ -1,0 +1,3 @@
+# Security Documentation
+
+This folder houses security policies and frameworks for the AI video pipeline. All guidance must ensure no hardcoded API keys, mandatory user input validation, timeout and retry logic for API calls, and error handling via custom exceptions.

--- a/docs/security/securityFramework.md
+++ b/docs/security/securityFramework.md
@@ -1,0 +1,3 @@
+# Security Framework
+
+Placeholder for the overarching security framework. It will detail strategies to avoid hardcoded API keys, enforce input validation, implement timeout and retry logic, and use custom exceptions for error handling.

--- a/docs/ux/README.md
+++ b/docs/ux/README.md
@@ -1,0 +1,3 @@
+# UX Documentation
+
+This folder outlines user experience guidelines for the AI video pipeline. Designs must reflect security requirements: no hardcoded API keys, thorough user input validation, timeout and retry logic for API calls, and robust error handling with custom exceptions.


### PR DESCRIPTION
## Summary
- scaffold documentation directories for architecture, security, requirements, UX, and personas
- add placeholder markdown files and README stubs referencing core security requirements

## Testing
- `ruff check docs`
- `black --check docs`
- `mypy docs`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6898210cf54083229b3e4f2df0c567b1