### PR TITLE
[agent] scaffold infrastructure directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,3 +21,7 @@ API_KEY = os.environ["VIDEO_API_KEY"]
 
 Ensure each variable is validated before use and avoid committing `.env` files to version control.
 
+
+## Deployment Notes
+
+Deployment scripts must source API keys from environment variables and include retry logic for API calls.

--- a/alerts/README.md
+++ b/alerts/README.md
@@ -1,0 +1,3 @@
+# Alerts
+
+Placeholder for alerting rules and guidance.

--- a/charts/placeholder.yaml
+++ b/charts/placeholder.yaml
@@ -1,0 +1,1 @@
+# placeholder

--- a/ci-cd/placeholder.yaml
+++ b/ci-cd/placeholder.yaml
@@ -1,0 +1,1 @@
+# placeholder

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1,0 +1,3 @@
+# Deploy
+
+Deployment scripts must source API keys from environment variables and include retry logic for external calls.

--- a/environments/placeholder.yaml
+++ b/environments/placeholder.yaml
@@ -1,0 +1,1 @@
+# placeholder

--- a/infra/README.md
+++ b/infra/README.md
@@ -1,0 +1,3 @@
+# Infra
+
+Placeholder for legacy infrastructure assets.

--- a/infrastructure/README.md
+++ b/infrastructure/README.md
@@ -1,0 +1,3 @@
+# Infrastructure
+
+Placeholder for infrastructure configuration files.

--- a/k8s/placeholder.yaml
+++ b/k8s/placeholder.yaml
@@ -1,0 +1,1 @@
+# placeholder

--- a/logging/README.md
+++ b/logging/README.md
@@ -1,0 +1,3 @@
+# Logging
+
+Placeholder for logging configuration and documentation.

--- a/monitoring/README.md
+++ b/monitoring/README.md
@@ -1,0 +1,3 @@
+# Monitoring
+
+Placeholder for monitoring configuration and docs.

--- a/observability/README.md
+++ b/observability/README.md
@@ -1,0 +1,3 @@
+# Observability
+
+Placeholder for observability tools and configs.

--- a/operations/README.md
+++ b/operations/README.md
@@ -1,0 +1,3 @@
+# Operations
+
+Placeholder for operational procedures.

--- a/platform/placeholder.yaml
+++ b/platform/placeholder.yaml
@@ -1,0 +1,1 @@
+# placeholder

--- a/runbooks/README.md
+++ b/runbooks/README.md
@@ -1,0 +1,3 @@
+# Runbooks
+
+Placeholder for operational runbooks.


### PR DESCRIPTION
## Summary
- scaffold infrastructure and operations directories with placeholder files
- document that deployment scripts must use env-sourced API keys and include retry logic

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689823967d148322a7a1ec5082d161e1