### PR TITLE
[agent] Add security directory with placeholder guidelines

### DIFF
--- a/security/README.md
+++ b/security/README.md
@@ -1,0 +1,9 @@
+# Security Guidelines
+
+This directory holds security policies for different stages of the pipeline.
+
+- Always validate user inputs before processing.
+- Use try/except blocks with custom exceptions for all operations.
+- Access secrets like API keys via environment variables; never hardcode them.
+
+Subdirectories provide stage-specific details.

--- a/security/compliance/README.md
+++ b/security/compliance/README.md
@@ -1,0 +1,7 @@
+# Compliance Security Guidelines
+
+- Enforce strict input validation to meet regulatory requirements.
+- Use try/except blocks with custom exceptions to handle compliance-related errors.
+- Manage compliance secrets through environment variables to prevent exposure.
+
+This placeholder will be replaced with detailed compliance security policies.

--- a/security/development/README.md
+++ b/security/development/README.md
@@ -1,0 +1,7 @@
+# Development Security Guidelines
+
+- Always validate all user inputs before processing.
+- Wrap logic in try/except blocks with custom exceptions.
+- Load secrets and API keys from environment variables; never hardcode.
+
+This placeholder will be replaced with detailed development security policies.

--- a/security/integration/README.md
+++ b/security/integration/README.md
@@ -1,0 +1,7 @@
+# Integration Security Guidelines
+
+- Validate all incoming data from integrated systems before use.
+- Implement try/except blocks with custom exceptions around integration points.
+- Fetch secrets from environment variables to configure integrations securely.
+
+This placeholder will be replaced with detailed integration security policies.

--- a/security/testing/README.md
+++ b/security/testing/README.md
@@ -1,0 +1,7 @@
+# Testing Security Guidelines
+
+- Mandatory input validation is required for all test data.
+- Use try/except with custom exceptions when tests interact with external resources.
+- Store test secrets in environment variables; avoid committing them to the repo.
+
+This placeholder will be replaced with detailed testing security policies.


### PR DESCRIPTION
## Summary
- scaffold `security/` tree with development, testing, integration, and compliance folders
- add placeholder READMEs emphasizing input validation, custom exception handling, and env-var secrets

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6898287d713483228c415b90b741391f